### PR TITLE
Implement product table pagination

### DIFF
--- a/src/app/(main)/_components/tables/productsDataTable.tsx
+++ b/src/app/(main)/_components/tables/productsDataTable.tsx
@@ -169,7 +169,10 @@ const ProductsTable = () => {
   };
 
   // Fetch products data
-  const { data: products, isLoading, error: isError } = useProducts();
+  const { data: products, isLoading, error: isError } = useProducts(
+    currentPage,
+    rowsPerPage
+  );
   const { data: subCategories, isLoading: SubCategoryLoading, error: subCategoriesError } = useFetchSubCategories();
   const { data: categories, isLoading: categoryLoading, error: categoriesError } = useFetchCategories();
 
@@ -203,9 +206,11 @@ const ProductsTable = () => {
     return 0;
   });
 
-  const totalPages = Math.ceil(sortedData.length / rowsPerPage);
-  const startIndex = (currentPage - 1) * rowsPerPage;
-  const paginatedData = sortedData.slice(startIndex, startIndex + rowsPerPage);
+  const page = products?.data?.page ?? 1;
+  const limit = products?.data?.limit ?? rowsPerPage;
+  const totalPages = products?.data?.totalPages ?? 1;
+  const startIndex = (page - 1) * limit;
+  const paginatedData = sortedData;
   // const paginatedData: FlattenProductsData[] | [] = [];
 
   // const requestSort = (key: string) => {
@@ -384,11 +389,10 @@ const ProductsTable = () => {
 
       <div className="flex items-center justify-between mt-4">
         <div className="flex items-center gap-2">
-          {/* <span className="text-sm text-gray-500">
-            Showing {Math.min(startIndex + 1, sortedData.length)} to{" "}
-            {Math.min(startIndex + rowsPerPage, sortedData.length)} of{" "}
-            {sortedData.length} entries
-          </span> */}
+          <span className="text-sm text-gray-500">
+            Showing {startIndex + 1} to {startIndex + paginatedData.length} of{' '}
+            {products?.data?.totalResults ?? paginatedData.length} entries
+          </span>
           <Select
             value={rowsPerPage.toString()}
             onValueChange={(value) => {
@@ -421,7 +425,6 @@ const ProductsTable = () => {
                 }
               />
             </PaginationItem>
-            {/* 
             {[...Array(totalPages)].map((_, index) => {
               const pageNumber = index + 1;
 
@@ -462,7 +465,7 @@ const ProductsTable = () => {
                     : "cursor-pointer"
                 }
               />
-            </PaginationItem> */}
+            </PaginationItem>
           </PaginationContent>
         </Pagination>
       </div>

--- a/src/app/(main)/_components/tables/productsDataTable.tsx
+++ b/src/app/(main)/_components/tables/productsDataTable.tsx
@@ -206,9 +206,11 @@ const ProductsTable = () => {
     return 0;
   });
 
-  const page = products?.data?.page ?? 1;
-  const limit = products?.data?.limit ?? rowsPerPage;
-  const totalPages = products?.data?.totalPages ?? 1;
+  const {
+    page = 1,
+    limit = rowsPerPage,
+    totalPages = 1,
+  } = (products?.data as FetchProductsResponse | undefined) || {};
   const startIndex = (page - 1) * limit;
   const paginatedData = sortedData;
   // const paginatedData: FlattenProductsData[] | [] = [];

--- a/src/app/(main)/actions.ts
+++ b/src/app/(main)/actions.ts
@@ -265,7 +265,7 @@ export async function uploadProductImages(
 export async function getProducts(
   page = 1,
   limit = 10
-): Promise<FetchResponse> {
+): Promise<FetchResponse<FetchProductsResponse>> {
   try {
     const res = await getAllProductsQuery({
       page,

--- a/src/hooks/use-products.tsx
+++ b/src/hooks/use-products.tsx
@@ -4,7 +4,7 @@ import { getProducts } from "@/app/(main)/actions";
 import { useQuery } from "@tanstack/react-query";
 
 export function useProducts(page = 1, limit = 10) {
-  return useQuery({
+  return useQuery<FetchResponse<FetchProductsResponse>>({
     queryKey: ["products", page, limit], // Key includes pagination to prevent stale cache
     queryFn: () => getProducts(page, limit),
     staleTime: 0, // Always fetch fresh data


### PR DESCRIPTION
## Summary
- fetch product data per page in ProductsTable
- show total entries and page numbers when browsing products

## Testing
- `./scripts/setup.sh`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c354a15b4832ba956b4985adb9356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated product table to use server-side pagination for more accurate and efficient data display.
  - Pagination controls and entry range display now reflect server-provided information for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->