### PR TITLE
Fix getProducts catch return type

### DIFF
--- a/src/app/(main)/actions.ts
+++ b/src/app/(main)/actions.ts
@@ -282,7 +282,7 @@ export async function getProducts(
     return {
       success: false,
       message: "Failed to fetch products",
-      data: null,
+      // intentionally omit data to keep type expectations
     };
   }
 }


### PR DESCRIPTION
## Summary
- fix `getProducts` to omit `data` on error cases
- run ESLint to verify type safety

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c3a156190832ba9ff24abb47f5655