### PR TITLE
Fix pagination meta usage

### DIFF
--- a/src/app/(main)/_components/tables/productsDataTable.tsx
+++ b/src/app/(main)/_components/tables/productsDataTable.tsx
@@ -203,9 +203,14 @@ const ProductsTable = () => {
     return 0;
   });
 
-  const totalPages = Math.ceil(sortedData.length / rowsPerPage);
-  const startIndex = (currentPage - 1) * rowsPerPage;
-  const paginatedData = sortedData.slice(startIndex, startIndex + rowsPerPage);
+  const productMeta = products?.data as FetchProductsResponse | undefined;
+
+  const page = productMeta?.page ?? 1;
+  const limit = productMeta?.limit ?? rowsPerPage;
+  const totalPages = productMeta?.totalPages ?? 1;
+
+  const startIndex = (page - 1) * limit;
+  const paginatedData = sortedData.slice(startIndex, startIndex + limit);
   // const paginatedData: FlattenProductsData[] | [] = [];
 
   // const requestSort = (key: string) => {


### PR DESCRIPTION
## Summary
- ensure pagination metadata uses optional chaining
- compute start index using fetched page and limit

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684c3a1d5428832b8f97c9b8e4587fec